### PR TITLE
Basic Chunk Class

### DIFF
--- a/include/core/camera/Camera.h
+++ b/include/core/camera/Camera.h
@@ -10,12 +10,12 @@
 
 
 enum CameraMovement {
-    FORWARD,
-    BACKWARD,
-    LEFT,
-    RIGHT,
-    UP,
-    DOWN
+    CAM_FORWARD,
+    CAM_BACKWARD,
+    CAM_LEFT,
+    CAM_RIGHT,
+    CAM_UP,
+    CAM_DOWN
 };
 
 class Camera {

--- a/include/core/registers/BlockRegister.h
+++ b/include/core/registers/BlockRegister.h
@@ -7,10 +7,10 @@
 #include <string>
 #include <algorithm>
 #include <vector>
-#include <unordered_map>
 #include <nlohmann/json.hpp>
 
 #include "graphics/Vertex.h"
+#include "core/world/Block.h"
 
 #if defined(_WIN32)
 #include <filesystem>
@@ -20,50 +20,20 @@
 
 #define ENUM_ENTRY(name) {#name, BLOCKTYPE::name}
 
-enum BLOCKTYPE {
-    AIR,
-    DIRT,
-    GRASS,
-    STONE,
-    WOOD,
-    LEAVES,
-    SAND
-};
-
 std::unordered_map<std::string, BLOCKTYPE> createBlockTypeMap();
-
-struct Block {
-    std::string name;
-    int ID;
-
-    BLOCKTYPE type;
-
-    bool isSolid;
-    bool isTransparent;
-    bool isAir;
-
-    std::vector<Vertex> vertices;
-    std::vector<GLuint> indices;
-
-    std::vector<std::string> textures;
-    std::string model;
-
-    std::vector<std::string> states;
-
-    Block(std::string name, int ID, bool solid = false, bool transparent = true, bool air = true, BLOCKTYPE type = AIR)
-        : name(name), ID(ID), isSolid(solid), isTransparent(transparent), isAir(air), type(type) {}
-    Block() {}
-};
 
 class BlockRegister {
 public:
     std::vector<Block> blocks;
 
+    static void setInstance(BlockRegister* instance);
+    static BlockRegister& instance();
+
     BlockRegister();
     ~BlockRegister();
 
-    Block getBlockByName(std::string name);
-    Block getBlockByIndex(int index);
+    const Block getBlockByName(std::string name);
+    const Block getBlockByIndex(int index);
     int getBlockIndex(std::string name);
 
 private:
@@ -80,6 +50,8 @@ private:
 
     void linkModelToBlock(Block& block);
     void link_block_full(Block& block);
+
+    static BlockRegister* s_instance;
 };
 
 #endif

--- a/include/core/world/Block.h
+++ b/include/core/world/Block.h
@@ -1,0 +1,66 @@
+#ifndef BLOCK_H
+#define BLOCK_H
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+#include "graphics/Vertex.h"
+
+// Enum for block types
+enum BLOCKTYPE {
+    AIR,
+    DIRT,
+    GRASS,
+    STONE,
+    WOOD,
+    LEAVES,
+    SAND
+};
+
+// Enum for block faces
+enum Face {
+    BACK = 0,
+    BOTTOM = 1,
+    FRONT = 2,
+    LEFT = 3,
+    RIGHT = 4,
+    TOP = 5
+};
+
+// Offsets for each face in 3D space
+const glm::ivec3 FACE_OFFSETS[6] = {
+    {0, 0, -1}, // BACK
+    {0, -1, 0}, // BOTTOM
+    {0, 0, 1},  // FRONT
+    {-1, 0, 0}, // LEFT
+    {1, 0, 0},  // RIGHT
+    {0, 1, 0}   // TOP
+};
+
+// Block class representing a block in the world
+struct Block {
+    std::string name;
+    int ID;
+
+    BLOCKTYPE type;
+
+    bool isSolid;
+    bool isTransparent;
+    bool isAir;
+
+    std::vector<Vertex> vertices;
+    std::vector<GLuint> indices;
+
+    std::vector<std::string> textures;
+    std::string model;
+
+    std::vector<std::string> states;
+
+    Block(std::string name, int ID, bool solid = false, bool transparent = true, bool air = true, BLOCKTYPE type = AIR)
+        : name(name), ID(ID), isSolid(solid), isTransparent(transparent), isAir(air), type(type) {}
+    Block() {}
+};
+
+#endif

--- a/include/core/world/Chunk.h
+++ b/include/core/world/Chunk.h
@@ -1,0 +1,31 @@
+#ifndef chunk_h
+#define chunk_h
+
+#include <array>
+#include <stdexcept>
+
+#include "core/registers/BlockRegister.h"
+
+constexpr int CHUNK_SIZE = 16;
+constexpr int CHUNK_VOLUME = CHUNK_SIZE * CHUNK_SIZE * CHUNK_SIZE;
+
+class Chunk {
+public:
+    Chunk();
+    ~Chunk();
+
+    const Block& getBlock(int x, int y, int z);
+    int getBlockID(int x, int y, int z);
+    void setBlockID(int x, int y, int z, int blockID);
+
+    void generateMesh(std::vector<Vertex>& vertices, std::vector<GLuint>& indices);
+
+private:
+    std::array<int, CHUNK_VOLUME> blocks;
+
+    int index(int x, int y, int z);
+
+    std::vector<Vertex> getFaceVertices(int face, const Block& block);
+};
+
+#endif

--- a/shaders/block.frag
+++ b/shaders/block.frag
@@ -14,7 +14,7 @@ out vec4 FragColor;
 
 void main()
 {
-    float ambient = 0.2;
+    float ambient = 0.6;
 
     vec3 Normal = normalize(normal);
     vec3 lightDirection = normalize(lightPos - curPos);

--- a/src/core/camera/Camera.cpp
+++ b/src/core/camera/Camera.cpp
@@ -22,22 +22,22 @@ void Camera::updateCameraMatrix(float nearPlane, float farPlane, GLFWwindow* win
 void Camera::updatePosition(CameraMovement direction, float deltaTime) {
     float velocity = movementSpeed * deltaTime;
 
-    if (direction == FORWARD) {
+    if (direction == CAM_FORWARD) {
         position += front * velocity;
     }
-    if (direction == BACKWARD) {
+    if (direction == CAM_BACKWARD) {
         position -= front * velocity;
     }
-    if (direction == LEFT) {
+    if (direction == CAM_LEFT) {
         position -= right * velocity;
     }
-    if (direction == RIGHT) {
+    if (direction == CAM_RIGHT) {
         position += right * velocity;
     }
-    if (direction == UP) {
+    if (direction == CAM_UP) {
         position += up * velocity;
     } 
-    if (direction == DOWN) {
+    if (direction == CAM_DOWN) {
         position -= up * velocity;
     }
 }

--- a/src/core/registers/BlockRegister.cpp
+++ b/src/core/registers/BlockRegister.cpp
@@ -13,6 +13,23 @@ std::unordered_map<std::string, BLOCKTYPE> createBlockTypeMap()  {
     };
 };
 
+// Static instance of BlockRegister
+BlockRegister* BlockRegister::s_instance = nullptr;
+
+// Sets the static instance of BlockRegister
+void BlockRegister::setInstance(BlockRegister* instance) {
+    s_instance = instance;
+}
+
+// Returns the static instance of BlockRegister
+BlockRegister& BlockRegister::instance() {
+    if (!s_instance) {
+        s_instance = new BlockRegister();
+    }
+    return *s_instance;
+}
+
+// Default constructor
 BlockRegister::BlockRegister() {
     parseBlockRegistryJson();
     loadBlocks();
@@ -22,7 +39,7 @@ BlockRegister::BlockRegister() {
 BlockRegister::~BlockRegister() {}
 
 // Retrieves a block by its name from the registered blocks
-Block BlockRegister::getBlockByName(std::string name) {
+const Block BlockRegister::getBlockByName(std::string name) {
     for (Block block : blocks) {
         if (block.name == name) {
             return block;
@@ -33,7 +50,7 @@ Block BlockRegister::getBlockByName(std::string name) {
 }
 
 // Retrieves a block by its index from the registered blocks
-Block BlockRegister::getBlockByIndex(int index) {
+const Block BlockRegister::getBlockByIndex(int index) {
     if (index < blocks.size()) {
         return blocks[index];
     }
@@ -55,7 +72,6 @@ int BlockRegister::getBlockIndex(std::string name) {
 // Registers a new block with the specified properties
 void BlockRegister::registerBlock(std::string name, std::vector<std::string> states, std::vector<std::string> textures,
                                   std::string model, bool solid, bool transparent, bool air, BLOCKTYPE type) {
-
     Block block;
 
     block.isSolid = solid;

--- a/src/core/world/Chunk.cpp
+++ b/src/core/world/Chunk.cpp
@@ -1,0 +1,146 @@
+#include "core/world/chunk.h"
+
+Chunk::Chunk() {
+    blocks.fill(0); // Initialize all blocks to air
+}
+
+Chunk::~Chunk() {}
+
+// Converts 3D coordinates to a 1D index for the blocks array
+int Chunk::index(int x, int y, int z) {
+    if (x < 0 || x >= CHUNK_SIZE || y < 0 || y >= CHUNK_SIZE || z < 0 || z >= CHUNK_SIZE) {
+        return -1; // Out of bounds
+    }
+    return x + (y * CHUNK_SIZE * CHUNK_SIZE) + (z * CHUNK_SIZE);
+}
+
+// Retrieves the vertices for a specific face of the block
+std::vector<Vertex> Chunk::getFaceVertices(int face, const Block& block) {
+    std::vector<Vertex> faceVertices;
+    
+    if (face == BACK) {
+        faceVertices.push_back(block.vertices[0]);
+        faceVertices.push_back(block.vertices[1]);
+        faceVertices.push_back(block.vertices[2]);
+        faceVertices.push_back(block.vertices[3]);
+    } else if (face == BOTTOM) {
+        faceVertices.push_back(block.vertices[4]);
+        faceVertices.push_back(block.vertices[5]);
+        faceVertices.push_back(block.vertices[6]);
+        faceVertices.push_back(block.vertices[7]);
+    } else if (face == FRONT) {
+        faceVertices.push_back(block.vertices[8]);
+        faceVertices.push_back(block.vertices[9]);
+        faceVertices.push_back(block.vertices[10]);
+        faceVertices.push_back(block.vertices[11]);
+    } else if (face == LEFT) {
+        faceVertices.push_back(block.vertices[12]);
+        faceVertices.push_back(block.vertices[13]);
+        faceVertices.push_back(block.vertices[14]);
+        faceVertices.push_back(block.vertices[15]);
+    } else if (face == RIGHT) {
+        faceVertices.push_back(block.vertices[16]);
+        faceVertices.push_back(block.vertices[17]);
+        faceVertices.push_back(block.vertices[18]);
+        faceVertices.push_back(block.vertices[19]);
+    } else if (face == TOP) {
+        faceVertices.push_back(block.vertices[20]);
+        faceVertices.push_back(block.vertices[21]);
+        faceVertices.push_back(block.vertices[22]);
+        faceVertices.push_back(block.vertices[23]);
+    }
+    else {
+        std::cerr << "Invalid face index: " << face << std::endl;
+        return faceVertices; // Return empty vector if invalid face
+    }
+    return faceVertices;
+}
+
+// Retrieves a block from the blocks array using 3D coordinates
+const Block& Chunk::getBlock(int x, int y, int z) {
+    int idx = index(x, y, z);
+    if (idx == -1) {
+        std::cerr << "Chunk::getBlock: index out of chunk bounds at " << x << ", " << y << ", " << z << std::endl;
+        return BlockRegister::instance().blocks[0]; // Return air block if out of bounds
+    }
+    return BlockRegister::instance().blocks[blocks[idx]];
+}
+
+// Retrieves the block ID from the blocks array using 3D coordinates
+int Chunk::getBlockID(int x, int y, int z) {
+    int idx = index(x, y, z);
+    if (idx == -1) {
+        std::cerr << "Chunk::getBlockID: index out of chunk bounds at " << x << ", " << y << ", " << z << std::endl;
+        return -1;
+    }
+    return blocks[idx];
+}
+
+// Sets the block ID in the blocks array using 3D coordinates
+void Chunk::setBlockID(int x, int y, int z, int blockID) {
+    int idx = index(x, y, z);
+    if (idx == -1) {
+        std::cerr << "Chunk::setBlockID: index out of chunk bounds at " << x << ", " << y << ", " << z << std::endl;
+        return;
+    }
+    blocks[idx] = blockID;
+}
+
+// Generates the mesh for the chunk based on the blocks
+void Chunk::generateMesh(std::vector<Vertex>& vertices, std::vector<GLuint>& indices) {
+    vertices.clear();
+    indices.clear();
+
+    GLuint indexOffset = 0;
+
+    setBlockID(2, 1, 10, 1);
+
+    for (int x = 0; x < CHUNK_SIZE; ++x) {
+        for (int y = 0; y < CHUNK_SIZE; ++y) {
+            for (int z = 0; z < CHUNK_SIZE; ++z) {
+                const Block block = getBlock(x, y, z);
+
+                if (block.isAir) continue;
+
+                for (int face = 0; face < 6; ++face) {
+                    glm::ivec3 offset = FACE_OFFSETS[face];
+                    int nx = x + offset.x;
+                    int ny = y + offset.y;
+                    int nz = z + offset.z;
+
+                    // if neighbor is out of bounds, add the face to the mesh
+                    if (nx < 0 || nx >= CHUNK_SIZE || ny < 0 || ny >= CHUNK_SIZE || nz < 0 || nz >= CHUNK_SIZE) {
+                        const auto& faceVertices = getFaceVertices(face, block);
+                        for (const auto& faceVertex : faceVertices) {
+                            Vertex modifiedVertex = faceVertex;
+                            modifiedVertex.position = glm::vec3(x, y, z) + faceVertex.position;
+                            vertices.push_back(modifiedVertex);
+                        }
+
+                        indices.insert(indices.end(), {
+                            indexOffset, indexOffset + 2, indexOffset + 1,
+                            indexOffset, indexOffset + 3, indexOffset + 2
+                        });                        
+                        indexOffset += 4;
+                        continue;
+                    }
+
+                    if (!BlockRegister::instance().getBlockByIndex(getBlockID(nx, ny, nz)).isTransparent) continue;
+
+                    const auto& faceVertices = getFaceVertices(face, block);
+                    for (const auto& faceVertex : faceVertices) {
+                        Vertex modifiedVertex = faceVertex;
+                        modifiedVertex.position = glm::vec3(x, y, z) + faceVertex.position;
+                        vertices.push_back(modifiedVertex);
+                    }
+
+                    indices.insert(indices.end(), {
+                        indexOffset, indexOffset + 2, indexOffset + 1,
+                        indexOffset, indexOffset + 3, indexOffset + 2
+                    });                    
+                    indexOffset += 4;
+                }
+            }
+        }
+    }
+}

--- a/src/input/DetectInput.cpp
+++ b/src/input/DetectInput.cpp
@@ -25,22 +25,22 @@ void processInput(GLFWwindow* window, Camera* camera, float deltaTime, glm::vec3
         glfwSetWindowShouldClose(window, true);
     }
     if (glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS) {
-        camera->updatePosition(FORWARD, deltaTime);
+        camera->updatePosition(CAM_FORWARD, deltaTime);
     }
     if (glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS) {
-        camera->updatePosition(BACKWARD, deltaTime);
+        camera->updatePosition(CAM_BACKWARD, deltaTime);
     }
     if (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS) {
-        camera->updatePosition(LEFT, deltaTime);
+        camera->updatePosition(CAM_LEFT, deltaTime);
     }
     if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS) {
-        camera->updatePosition(RIGHT, deltaTime);
+        camera->updatePosition(CAM_RIGHT, deltaTime);
     }
     if (glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_PRESS) {
-        camera->updatePosition(UP, deltaTime);
+        camera->updatePosition(CAM_UP, deltaTime);
     }
     if (glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS) {
-        camera->updatePosition(DOWN, deltaTime);
+        camera->updatePosition(CAM_DOWN, deltaTime);
     }
     if (glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS) {
         camera->movementSpeed = 3.5f;
@@ -58,21 +58,21 @@ void processInput(GLFWwindow* window, Camera* camera, float deltaTime, glm::vec3
     }
 
     if (glfwGetKey(window, GLFW_KEY_UP) == GLFW_PRESS) {
-        lightpos->x += 0.01f;
+        lightpos->x += 0.05f;
     }
     if (glfwGetKey(window, GLFW_KEY_DOWN) == GLFW_PRESS) {
-        lightpos->x -= 0.01f;
+        lightpos->x -= 0.05f;
     }
     if (glfwGetKey(window, GLFW_KEY_LEFT) == GLFW_PRESS) {
-        lightpos->z -= 0.01f;
+        lightpos->z -= 0.05f;
     }
     if (glfwGetKey(window, GLFW_KEY_RIGHT) == GLFW_PRESS) {
-        lightpos->z += 0.01f;
+        lightpos->z += 0.05f;
     }
     if (glfwGetKey(window, GLFW_KEY_PAGE_UP) == GLFW_PRESS) {
-        lightpos->y += 0.01f;
+        lightpos->y += 0.05f;
     }
     if (glfwGetKey(window, GLFW_KEY_PAGE_DOWN) == GLFW_PRESS) {
-        lightpos->y -= 0.01f;
+        lightpos->y -= 0.05f;
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "graphics/Texture.h"
 #include "input/DetectInput.h"
 #include "core/registers/AtlasRegister.h"
-#include "core/registers/BlockRegister.h"
+#include "core/world/Chunk.h"
 
 std::vector<Vertex> lightVertices = {
     {Vertex{glm::vec3(-0.1f, -0.1f,  0.1f)}},
@@ -69,12 +69,19 @@ int main() {
 
     blockAtlas.linkBlocksToAtlas(&blockRegister);
 
+    BlockRegister::setInstance(&blockRegister);
+
+    std::vector<Vertex> Tvertices;
+    std::vector<GLuint> Tindices;
+    Chunk chunk;
+    chunk.generateMesh(Tvertices, Tindices);
+
     Shader shaderProgram("../../shaders/block.vert", "../../shaders/block.frag");
 
     VertexArrayObject VAO;
     VAO.bind();
-    VAO.addVertexBuffer(blockRegister.blocks[BLOCK_NUM].vertices);
-    VAO.addElementBuffer(blockRegister.blocks[BLOCK_NUM].indices);
+    VAO.addVertexBuffer(Tvertices);
+    VAO.addElementBuffer(Tindices);
     VAO.addAttribute(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)0);
     VAO.addAttribute(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, normal));
     VAO.addAttribute(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, texCoords));
@@ -133,7 +140,7 @@ int main() {
         shaderProgram.setUniform3("lightPos", glm::vec3(lightPos.x, lightPos.y, lightPos.z));
         atlas.bind();
         VAO.bind();
-        glDrawElements(GL_TRIANGLES, blockRegister.blocks[BLOCK_NUM].indices.size(), GL_UNSIGNED_INT, 0);
+        glDrawElements(GL_TRIANGLES, Tindices.size(), GL_UNSIGNED_INT, 0);
 
         glUseProgram(lightShader.ID);
         lightShader.setUniform4("cameraMatrix", camera.cameraMatrix);


### PR DESCRIPTION
Implements a basic chunk class that holds a 1D array of block IDs. 

Generates a mesh based on the block IDs, only including outside vertices and faces. 
If the face of a block is exposed, then the 4 vertices from the face are attached to the mesh.

Updated light source movement speed for the updated scale of the project, also increased ambient lighting for the time being

Implements #8 