### PR TITLE
Multi Threaded Chunk Generation and Meshing

### DIFF
--- a/include/core/player/Player.h
+++ b/include/core/player/Player.h
@@ -8,6 +8,9 @@
 
 class Player {
 public:
+    static void setInstance(Player* instance);
+    static Player& instance();
+
     Player(GLFWwindow* window);
 
     void update(float deltaTime, GLFWwindow* window);
@@ -20,9 +23,13 @@ public:
 
     Camera& getCamera();
 
+    int VIEW_DISTANCE = 3;
+
 private:
     Camera camera;
     void handleInput(GLFWwindow* window, float deltaTime);
+
+    static Player* s_instance;
 };
 
 #endif

--- a/include/core/player/Player.h
+++ b/include/core/player/Player.h
@@ -23,7 +23,7 @@ public:
 
     Camera& getCamera();
 
-    int VIEW_DISTANCE = 3;
+    int VIEW_DISTANCE = 4;
 
 private:
     Camera camera;

--- a/include/core/threads/OpenMP.h
+++ b/include/core/threads/OpenMP.h
@@ -1,0 +1,37 @@
+#ifndef OPENMP_HELPER_H
+#define OPENMP_HELPER_H
+
+#include <omp.h>
+#include <iostream>
+
+struct ThreadBudget {
+    int ChunkGenerationThreads;
+    int MeshGenerationThreads;
+    int OtherThreads;
+};
+
+void setThreadBudget(ThreadBudget& threadBudget) {
+
+    #ifdef _OPENMP
+        fprintf(stderr, "OpenMP is supported -- version = %d\n", _OPENMP);
+    #else
+        fprintf(stderr, "No OpenMP support!\n");
+    #endif
+    
+        omp_set_dynamic(0);
+    
+        int numThreads = omp_get_max_threads();
+        omp_set_num_threads(numThreads);
+    
+        if (numThreads >= 8) {
+            threadBudget = {6, 2, 0};
+        } else if (numThreads >= 6) {
+            threadBudget = {4, 2, 0};
+        } else if (numThreads >= 4) {
+            threadBudget = {2, 1, 1};
+        } else {
+            threadBudget = {1, 1, 0};
+        }
+    }
+
+#endif

--- a/include/core/threads/ThreadSafeQueue.h
+++ b/include/core/threads/ThreadSafeQueue.h
@@ -1,0 +1,44 @@
+#ifndef THREAD_SAFE_QUEUE_H
+#define THREAD_SAFE_QUEUE_H
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+template <typename T>
+class ThreadSafeQueue {
+public:
+    void push(const T& value) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        queue_.push(value);
+        cond_var_.notify_one();
+    }
+
+    bool tryPop(T& value) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (queue_.empty()) return false;
+        value = queue_.front();
+        queue_.pop();
+        return true;
+    }
+
+    T waitPop() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cond_var_.wait(lock, [this] { return !queue_.empty(); });
+        T value = queue_.front();
+        queue_.pop();
+        return value;
+    }
+
+    bool empty() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return queue_.empty();
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::queue<T> queue_;
+    std::condition_variable cond_var_;
+};
+
+#endif

--- a/include/core/world/Chunk.h
+++ b/include/core/world/Chunk.h
@@ -40,6 +40,9 @@ struct ChunkMesh {
     std::vector<GLuint> indices;
     bool isUploaded = false;
     bool needsUpdate = true;
+    bool vaoInitialized = false;
+    bool shouldRender = true;
+    bool isEmpty = true;
 };
 
 class Chunk {

--- a/include/core/world/FlatWorld.h
+++ b/include/core/world/FlatWorld.h
@@ -1,22 +1,32 @@
 #ifndef FLAT_WORLD_H
 #define FLAT_WORLD_H
 
-#include <queue>
 #include <unordered_set>
+#include <omp.h>
 
 #include "core/world/Chunk.h"
+#include "core/threads/ThreadSafeQueue.h"
+#include "core/player/Player.h"
+
 
 struct ChunkMeshTask {
     ChunkPosition pos;
     float priority;
 
     bool operator<(const ChunkMeshTask& other) const {
-        return priority > other.priority;
+        return priority < other.priority;
     }
 };
+
 class FlatWorld {
 public:
-    void generateNecessaryChunkMeshes(int maxPerFrame = 2, const glm::vec3& playerPos = glm::vec3(0.0f, 0.0f, 0.0f));
+    FlatWorld();
+    ~FlatWorld();
+
+    void chunkWorkerThread();
+    void meshWorkerThread();
+
+    void generateMesh(const ChunkMeshTask& task);
 
     void setBlockAtWorldPosition(int wx, int wy, int wz, int blockID);
 
@@ -25,19 +35,24 @@ public:
     void markNeighborsDirty(const ChunkPosition& pos);
 
     void queueChunksForMeshing(const glm::vec3& playerPos);
-    void updateChunksAroundPlayer(int centerX, int centerY, int centerZ, const int VIEW_DISTANCE);
+    void updateChunksAroundPlayer(const glm::ivec3& playerChunk, const int VIEW_DISTANCE);
     void uploadChunkMeshes(int maxPerFrame = 2);
     void uploadMeshToGPU(Chunk& chunk);
 
-    void createChunks(int maxPerFrame = 2);
     void unloadDistantChunks(const glm::ivec3& centerChunk, const int VIEW_DISTANCE);
 
     std::unordered_map<ChunkPosition, Chunk, std::hash<ChunkPosition>> chunks;
 
-    std::queue<ChunkPosition> chunkCreationQueue;
+    ThreadSafeQueue<ChunkPosition> chunkCreationQueue;
+    ThreadSafeQueue<ChunkPosition> meshUploadQueue;
+    ThreadSafeQueue<ChunkMeshTask> meshGenerationQueue;
 
-    std::priority_queue<ChunkMeshTask> meshGenerationQueue;
-    std::queue<ChunkPosition> meshUploadQueue;
+private:
+    std::thread chunkThread;
+    std::thread meshThread;
+
+    std::atomic<bool> running = true;
+    mutable std::mutex chunkMutex;
 
 };
 

--- a/include/graphics/VertexArrayObject.h
+++ b/include/graphics/VertexArrayObject.h
@@ -11,6 +11,8 @@ class VertexArrayObject {
         VertexArrayObject();
         ~VertexArrayObject();
 
+        void init();
+
         void bind();
         void unbind();
         void deleteBuffers();

--- a/src/core/player/Player.cpp
+++ b/src/core/player/Player.cpp
@@ -1,5 +1,18 @@
 #include "core/player/Player.h"
 
+Player* Player::s_instance = nullptr;
+
+void Player::setInstance(Player* instance) {
+    s_instance = instance;
+}
+
+Player& Player::instance() {
+    if (!s_instance) {
+        s_instance = new Player(nullptr); // Pass nullptr for window, will be set later
+    }
+    return *s_instance;
+}
+
 Player::Player(GLFWwindow* window) : camera(glm::vec3(5.0f, 20.0f, 3.0f)) {
     camera.updateCameraMatrix(0.1f, 300.0f, window);
 }
@@ -26,7 +39,7 @@ glm::vec3 Player::getPosition() const {
 
 // Returns the player's current chunk position as a glm::ivec3 object
 glm::ivec3 Player::getChunkPosition() const {
-    return glm::ivec3(floor(camera.position.x / CHUNK_SIZE), 0, floor(camera.position.z / CHUNK_SIZE));
+    return glm::ivec3(floor(camera.position.x / CHUNK_SIZE), floor(camera.position.y / CHUNK_SIZE), floor(camera.position.z / CHUNK_SIZE));
 }
 
 // Returns a reference to the player's camera object

--- a/src/graphics/VertexArrayObject.cpp
+++ b/src/graphics/VertexArrayObject.cpp
@@ -1,12 +1,18 @@
 #include "graphics/VertexArrayObject.h"
 
 VertexArrayObject::VertexArrayObject() {
+    this->VAO = 0;
+    this->VBO = 0;
+    this->EBO = 0;
+}
+
+VertexArrayObject::~VertexArrayObject() {}
+
+void VertexArrayObject::init() {
     glGenVertexArrays(1, &VAO);
     glGenBuffers(1, &VBO);
     glGenBuffers(1, &EBO);
 }
-
-VertexArrayObject::~VertexArrayObject() {}
 
 void VertexArrayObject::bind() {
     glBindVertexArray(this->VAO);


### PR DESCRIPTION
Added 2 background threads to handle chunk creation and chunk meshing. These two threads push and pop from a new ThreadSafeQueue object, for queueing chunk creation, mesh generation, and mesh uploading. Currently, Mesh uploading to the GPU is still on the main thread.

This has boosted performance for dynamically unloading and loading chunks.