### PR TITLE
Pointer based chunk mesh uploads

### DIFF
--- a/include/core/player/Player.h
+++ b/include/core/player/Player.h
@@ -23,7 +23,7 @@ public:
 
     Camera& getCamera();
 
-    int VIEW_DISTANCE = 4;
+    int VIEW_DISTANCE = 5;
 
 private:
     Camera camera;

--- a/include/core/world/FlatWorld.h
+++ b/include/core/world/FlatWorld.h
@@ -44,7 +44,7 @@ public:
     std::unordered_map<ChunkPosition, Chunk, std::hash<ChunkPosition>> chunks;
 
     ThreadSafeQueue<ChunkPosition> chunkCreationQueue;
-    ThreadSafeQueue<ChunkPosition> meshUploadQueue;
+    ThreadSafeQueue<Chunk*> meshUploadQueue;
     ThreadSafeQueue<ChunkMeshTask> meshGenerationQueue;
 
 private:

--- a/src/core/player/Player.cpp
+++ b/src/core/player/Player.cpp
@@ -68,7 +68,7 @@ void Player::handleInput(GLFWwindow* window, float deltaTime) {
         camera.updatePosition(CAM_DOWN, deltaTime);
     }
     if (glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS) {
-        camera.movementSpeed = 7.5f;
+        camera.movementSpeed = 17.5f;
     }
     if (glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_RELEASE) {
         camera.movementSpeed = 3.5f;

--- a/src/core/world/Chunk.cpp
+++ b/src/core/world/Chunk.cpp
@@ -4,7 +4,7 @@ Chunk::Chunk() {
     blocks.fill(1); // Initialize all blocks to air
     for (int x = 0; x < CHUNK_SIZE; ++x) {
         for (int z = 0; z < CHUNK_SIZE; ++z) {
-            setBlockID(x, CHUNK_SIZE - 1, z, 2); // top layer (e.g., grass)
+            setBlockID(x, CHUNK_SIZE - 1, z, 2); // grass
             setBlockID(x, CHUNK_SIZE - 2, z, 3); // dirt
             setBlockID(x, CHUNK_SIZE - 3, z, 3); // dirt
             setBlockID(x, CHUNK_SIZE - 4, z, 3); // dirt

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,6 @@ int main() {
     FlatWorld world;
 
     Shader shaderProgram("../../shaders/block.vert", "../../shaders/block.frag");
-
     Shader lightShader("../../shaders/light.vert", "../../shaders/light.frag");
 
     VertexArrayObject lightVAO;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ int main() {
     atlas.setUniform(shaderProgram, "tex0", 0);
 
     glEnable(GL_DEPTH_TEST);
-    glEnable(GL_CULL_FACE);
+    //glEnable(GL_CULL_FACE);
 
     // Enable alpha values for textures
     // glEnable(GL_BLEND);
@@ -121,7 +121,7 @@ int main() {
 
         player.update(deltaTime, window);
 
-        world.uploadChunkMeshes(3);
+        world.uploadChunkMeshes(10);
 
         shaderProgram.setUniform4("cameraMatrix", player.getCamera().cameraMatrix);
         shaderProgram.setUniform3("camPos", player.getCamera().position);


### PR DESCRIPTION
When uploading chunk meshes to the GPU, chunk pointers are now passed in a queue instead of chunk positions. This prevents either of the 2 background threads that handle chunk mutex locking from freezing the main rendering loop.

Chunk generation is now extremely smooth with a minuscule impact on FPS.

Implements #45 