### PR TITLE
Terrain manipulation

### DIFF
--- a/include/core/player/Camera.h
+++ b/include/core/player/Camera.h
@@ -7,7 +7,14 @@
 #include<glm/gtx/rotate_vector.hpp>
 #include<glm/gtx/vector_angle.hpp>
 #include <GLFW/glfw3.h>
+#include <optional>
 
+class World;
+
+struct RaycastHit {
+    glm::ivec3 block;
+    glm::ivec3 normal;
+};
 
 enum CameraMovement {
     CAM_FORWARD,
@@ -51,6 +58,8 @@ public:
     void updatePosition(CameraMovement direction, float deltaTime);
     void processMouseMovement(GLFWwindow* window, bool constrainPitch = true);
     void processMouseScroll(float yoffset);
+
+    std::optional<RaycastHit> raycastToBlock(const World& world, float maxDistance = 8.0f) const;
 
 private:
     void updateCameraVectors();

--- a/include/core/player/Player.h
+++ b/include/core/player/Player.h
@@ -6,6 +6,8 @@
 #include "core/player/Camera.h"
 #include "core/world/World.h"
 
+class Camera;
+
 class Player {
 public:
     static void setInstance(Player* instance);
@@ -13,7 +15,11 @@ public:
 
     Player(GLFWwindow* window);
 
+    std::optional<glm::ivec3> getHighlightedBlock() const;
+
     void update(float deltaTime, glm::vec3 *lightpos);
+
+    int selectedBlockID = 1;
 
     void setPosition(float x, float y, float z);
     void setPosition(const glm::vec3& pos);
@@ -32,6 +38,7 @@ private:
     GLFWwindow* window = nullptr;
 
     void handleInput(float deltaTime, glm::vec3 *lightpos);
+    std::optional<glm::ivec3> highlightedBlock;
 
     static Player* s_instance;
 };

--- a/include/core/world/World.h
+++ b/include/core/world/World.h
@@ -13,6 +13,9 @@ public:
 
     void init();
 
+    static void setInstance(World* instance);
+    static World& instance();
+
     void managerThread();
     void chunkWorkerThread();
     void meshWorkerThread();
@@ -35,6 +38,8 @@ public:
     void queueChunksForRemoval(const glm::ivec3& centerChunk, const int VIEW_DISTANCE);
     void unloadDistantChunks();
 
+    int getBlockIDAtWorldPosition(int wx, int wy, int wz) const;
+
     std::unordered_map<ChunkPosition, std::shared_ptr<Chunk>, std::hash<ChunkPosition>> chunks;
 
 private:
@@ -50,10 +55,14 @@ private:
     ThreadSafeQueue<std::shared_ptr<Chunk>> meshUploadQueue;
     ThreadSafeQueue<ChunkPosition> chunkRemovalQueue;
 
+    ThreadSafeQueue<std::shared_ptr<Chunk>> meshUpdateQueue;
+
     std::unordered_set<ChunkPosition> chunkPositionSet;
 
     int minY = -32;
     int maxY = 100;
+
+    static World* s_instance;
 
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ std::vector<GLuint> lightIndices = {
 };
 
 std::string programName = "TerraLink";
-std::string programVersion = "v0.1.8";
+std::string programVersion = "v0.2.0";
 std::string windowTitle = programName + " " + programVersion;
 
 int _fpsCount = 0, fps = 0;
@@ -66,6 +66,7 @@ int main() {
 
     World world;
     world.init();
+    World::setInstance(&world);
 
     Shader shaderProgram("../../shaders/block.vert", "../../shaders/block.frag");
     Shader lightShader("../../shaders/light.vert", "../../shaders/light.frag");
@@ -117,7 +118,7 @@ int main() {
 
             chunk->mesh.VAO.bind();
             glDrawElements(GL_TRIANGLES, chunk->mesh.indices.size(), GL_UNSIGNED_INT, 0);
-        }
+        }       
         
         glUseProgram(lightShader.ID);
         lightShader.setUniform4("cameraMatrix", player.getCamera().cameraMatrix);


### PR DESCRIPTION
Right-click now destroys blocks. Currently, E is set to place them. The scroll wheel cycles between all available blocks