### PR TITLE
Persistent World and Player saves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build/*
 
 # vcpkg directory
 vcpkg/
+
+# World saves
+saves/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,3 +42,8 @@ target_include_directories(TerraLink PRIVATE ${nlohmann_json_INCLUDE_DIRS})
 
 # STB (header-only)
 include_directories(${CMAKE_SOURCE_DIR}/vcpkg/installed/x64-windows/include)
+
+# ZSTD
+set(zstd_DIR "${CMAKE_SOURCE_DIR}/vcpkg/installed/x64-windows/share/zstd")
+find_package(zstd CONFIG REQUIRED)
+target_link_libraries(TerraLink PRIVATE zstd::libzstd_shared)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ run: build
 vcpkg:
 	@git clone https://github.com/microsoft/vcpkg.git
 	@./vcpkg/bootstrap-vcpkg.bat
-	@cd vcpkg && ./vcpkg install glfw3 glad glm stb nlohmann-json
+	@cd vcpkg && ./vcpkg install glfw3 glad glm stb nlohmann-json zstd
 
 gdb: 
 	@cd build/Debug && gdb TerraLink.exe

--- a/include/core/game/Game.h
+++ b/include/core/game/Game.h
@@ -1,0 +1,47 @@
+#ifndef GAME_H
+#define GAME_H
+
+#include <memory>
+#include <string>
+#include <filesystem>
+
+class World;
+
+class Game {
+public:
+    Game();
+    ~Game();
+
+    static void setInstance(Game* instance);
+    static Game& instance();
+
+    std::string getBasePath() const;
+    std::string getSavePath() const;
+
+    void init();
+    void tick();
+    void shutdown();
+
+    void setWorldSave(const std::string& saveName);
+    std::string getWorldSave() const;
+
+    World& getWorld();
+
+    std::string getGameVersion() const;
+
+private:
+    std::string curWorldSave;
+    std::unique_ptr<World> world;
+
+    bool DEV_MODE = true;
+    float gameVersionMajor = 2.f;
+    float gameVersionMinor = 1.1f;
+
+    std::filesystem::path basePath = DEV_MODE
+        ? std::filesystem::current_path().parent_path().parent_path()
+        : std::filesystem::current_path();
+    std::filesystem::path savePath = basePath / "saves/";
+    static Game* s_instance;
+};
+
+#endif

--- a/include/core/player/Camera.h
+++ b/include/core/player/Camera.h
@@ -3,7 +3,8 @@
 
 #define GLM_ENABLE_EXPERIMENTAL
 
-#include "../../graphics/Shader.h"
+#include "graphics/Shader.h"
+
 #include<glm/gtx/rotate_vector.hpp>
 #include<glm/gtx/vector_angle.hpp>
 #include <GLFW/glfw3.h>

--- a/include/core/world/BiomeNoise.h
+++ b/include/core/world/BiomeNoise.h
@@ -7,18 +7,7 @@
 namespace BiomeNoise {
     extern FastNoiseLite noiseGenerator;
 
-    inline void initializeNoiseGenerator() {
-        noiseGenerator.SetSeed(13372323);
-        noiseGenerator.SetNoiseType(FastNoiseLite::NoiseType_Perlin);
-        noiseGenerator.SetFrequency(0.01f);
-        noiseGenerator.SetFractalType(FastNoiseLite::FractalType_FBm);
-        noiseGenerator.SetFractalOctaves(3);
-        noiseGenerator.SetFractalLacunarity(2.17f);
-        noiseGenerator.SetFractalGain(0.62f);
-
-        // noiseGenerator.SetDomainWarpType(FastNoiseLite::DomainWarpType_BasicGrid);
-        // noiseGenerator.SetDomainWarpAmp(2.5f);
-    }
+    void initializeNoiseGenerator();
 
     float generateHills(int x, int z);
 

--- a/include/core/world/Chunk.h
+++ b/include/core/world/Chunk.h
@@ -1,5 +1,5 @@
-#ifndef chunk_h
-#define chunk_h
+#ifndef CHUNK_H
+#define CHUNK_H
 
 #include <array>
 #include <stdexcept>
@@ -69,6 +69,14 @@ public:
             return -1;
         }
         return blocks[idx];
+    }
+
+    std::array<uint16_t, CHUNK_VOLUME> getBlocks() const {
+        return blocks;
+    }
+
+    void setBlocks(const std::array<uint16_t, CHUNK_VOLUME>& newBlocks) {
+        blocks = newBlocks;
     }
     
     void setBlockID(int x, int y, int z, int blockID);

--- a/src/core/game/Game.cpp
+++ b/src/core/game/Game.cpp
@@ -1,0 +1,65 @@
+#include "core/game/Game.h"
+#include "core/world/World.h"
+
+
+Game::Game() {
+
+}
+
+Game::~Game() {
+    shutdown();
+}
+
+Game* Game::s_instance = nullptr;
+
+void Game::setInstance(Game* instance) {
+    s_instance = instance;
+}
+
+Game& Game::instance() {
+    if (!s_instance) {
+        s_instance = new Game();
+    }
+    return *s_instance;
+}
+
+std::string Game::getBasePath() const {
+    return basePath.string();
+}
+
+std::string Game::getSavePath() const {
+    return savePath.string();
+}
+
+void Game::init() {
+    world = std::make_unique<World>();
+    World::setInstance(world.get());
+    world->init();
+}
+
+void Game::tick() {
+
+}
+
+void Game::shutdown() {
+    if (world) {
+        world.reset();
+    }
+}
+
+std::string Game::getWorldSave() const {
+    return curWorldSave;
+}
+
+void Game::setWorldSave(const std::string& saveName) {
+    curWorldSave = saveName;
+}
+
+World& Game::getWorld() {
+    return *world;
+}
+
+std::string Game::getGameVersion() const {
+    return "v" + std::to_string(static_cast<int>(gameVersionMajor)) + "." +
+                 std::to_string(static_cast<int>(gameVersionMinor * 10));
+}

--- a/src/core/player/Player.cpp
+++ b/src/core/player/Player.cpp
@@ -10,7 +10,8 @@ void Player::setInstance(Player* instance) {
 
 Player& Player::instance() {
     if (!s_instance) {
-        s_instance = new Player(nullptr);
+        std::cerr << "Player::instance() called before Player::setInstance()!\n";
+        std::exit(1);
     }
     return *s_instance;
 }
@@ -84,7 +85,8 @@ void Player::setPosition(float x, float y, float z) {
 
 // Sets the player's position using a glm::vec3 object
 void Player::setPosition(const glm::vec3& pos) {
-    camera.position = pos;
+    playerPosition = pos;
+    camera.position = playerPosition + glm::vec3(0.0f, eyeOffset, 0.0f);
 }
 
 // Returns the player's current position as a glm::vec3 object
@@ -258,11 +260,19 @@ void Player::handleInput(float deltaTime, glm::vec3 *lightpos) {
         playerPosition = camera.position - glm::vec3(0.0f, eyeOffset, 0.0f);
     }
 
-    // if (auto hit = camera.raycastToBlock(World::instance())) {
-    //     highlightedBlock = hit->block;
-    // } else {
-    //     highlightedBlock.reset();
-    // }    
+    static bool lastF3 = false;
+    static bool lastR = false;
+    bool f3Down = glfwGetKey(window, GLFW_KEY_F3) == GLFW_PRESS;
+    bool rDown = glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS;
+
+    
+    if (f3Down && rDown && (!lastF3 || !lastR)) {
+        std::cout << "[DEBUG] F3 + R pressed: Reloading chunks around player\n";
+        // World::instance().needsFullReset = true;
+    }
+    lastF3 = f3Down;
+    lastR = rDown;
+
 }
 
 static void scrollCallback(GLFWwindow* window, double xoffset, double yoffset) {

--- a/src/core/registers/BlockRegister.cpp
+++ b/src/core/registers/BlockRegister.cpp
@@ -1,4 +1,5 @@
 #include "core/registers/BlockRegister.h"
+#include "core/game/Game.h"
 
 // Function to create a mapping from string names to block type enums
 std::unordered_map<std::string, BLOCKTYPE> createBlockTypeMap()  {
@@ -152,11 +153,11 @@ void BlockRegister::loadBlocks() {
     }
 
     #if defined(_WIN32)
-    if (!std::filesystem::exists("../../assets/maps/blocks/")) {
-        std::cerr << "Error locating folder: ../../assets/maps/blocks/" << std::endl;
+    if (!std::filesystem::exists(Game::instance().getBasePath() + "/assets/maps/blocks/")) {
+        std::cerr << "Error locating folder: ./assets/maps/blocks/" << std::endl;
         return;
     }
-    for (const auto& entry : std::filesystem::directory_iterator("../../assets/maps/blocks/")) {
+    for (const auto& entry : std::filesystem::directory_iterator(Game::instance().getBasePath() + "/assets/maps/blocks/")) {
         if (entry.is_regular_file() && entry.path().extension() == ".json") {
             std::ifstream blockFile(entry.path().string());
             if (!blockFile.is_open()) {
@@ -174,12 +175,12 @@ void BlockRegister::loadBlocks() {
     #else
     DIR* dir;
     struct dirent* ent;
-    if ((dir = opendir("../../assets/maps/blocks/")) != NULL) {
+    if ((dir = opendir(Game::instance().getBasePath() + "/assets/maps/blocks/")) != NULL) {
         while ((ent = readdir(dir)) != NULL) {
             if (ent->d_type == DT_REG) {
                 std::string filename = ent->d_name;
                 if (filename.substr(filename.find_last_of(".") + 1) == "json") {
-                    std::string fullPath = "../../assets/maps/blocks/" + filename;
+                    std::string fullPath = Game::instance().getBasePath() + "/assets/maps/blocks/" + filename;
                     std::ifstream blockFile(fullPath);
                     if (!blockFile.is_open()) {
                         std::cerr << "Failed to open block file: " << fullPath << std::endl;
@@ -205,9 +206,9 @@ void BlockRegister::saveBlockRegistryJson() {
         blockRegistryJson[name] = id;
     }
 
-    std::ofstream file("../../registry/block_registry.json");
+    std::ofstream file(Game::instance().getBasePath() + "/registry/block_registry.json");
     if (!file) {
-        std::cerr << "Error opening file for writing: ../../registry/block_registry.json" << std::endl;
+        std::cerr << "Error opening file for writing: ./registry/block_registry.json" << std::endl;
         return;
     }
 
@@ -217,9 +218,9 @@ void BlockRegister::saveBlockRegistryJson() {
 
 // Parses the block registry JSON file to create a mapping of block names to IDs
 void BlockRegister::parseBlockRegistryJson() {
-    std::ifstream file("../../registry/block_registry.json");
+    std::ifstream file(Game::instance().getBasePath() + "/registry/block_registry.json");
     if (!file) {
-        std::cerr << "Error opening file for reading: ../../registry/block_registry.json" << std::endl;
+        std::cerr << "Error opening file for reading: ./registry/block_registry.json" << std::endl;
         return;
     }
 
@@ -253,9 +254,10 @@ void BlockRegister::linkModelToBlock(Block& block) {
 // Json reading library reads textures on map in alphabetical order, default blocks must be created with BaBoFLRT order in mind
 void BlockRegister::link_block_full(Block& block) {
 
-    std::ifstream file("../../assets/models/block_full.obj");
+    std::string modelPath = Game::instance().getBasePath() + "/assets/models/block_full.obj";
+    std::ifstream file(modelPath);
     if (!file.is_open()) {
-        std::cerr << "Failed to open block model file: ../../assets/models/block_full.obj" << std::endl;
+        std::cerr << "Failed to open block model file: " << modelPath << std::endl;
         return;
     }
 
@@ -328,9 +330,11 @@ void BlockRegister::link_block_full(Block& block) {
 
 // Model specific linking for the covered cross model
 void BlockRegister::link_covered_cross(Block& block) {
-    std::ifstream file("../../assets/models/covered_cross.obj");
+
+    std::string modelPath = Game::instance().getBasePath() + "/assets/models/covered_cross.obj";
+    std::ifstream file(modelPath);
     if (!file.is_open()) {
-        std::cerr << "Failed to open plane model file: ../../assets/models/covered_cross.obj" << std::endl;
+        std::cerr << "Failed to open block model file: " << modelPath << std::endl;
         return;
     }
 

--- a/src/core/world/BiomeNoise.cpp
+++ b/src/core/world/BiomeNoise.cpp
@@ -1,8 +1,23 @@
 #include "core/world/BiomeNoise.h"
+#include "core/game/Game.h"
+#include "core/world/World.h"
 
 namespace BiomeNoise {
     
     FastNoiseLite noiseGenerator;
+    
+    void initializeNoiseGenerator() {
+        noiseGenerator.SetSeed(Game::instance().getWorld().getSeed());
+        noiseGenerator.SetNoiseType(FastNoiseLite::NoiseType_Perlin);
+        noiseGenerator.SetFrequency(0.01f);
+        noiseGenerator.SetFractalType(FastNoiseLite::FractalType_FBm);
+        noiseGenerator.SetFractalOctaves(3);
+        noiseGenerator.SetFractalLacunarity(2.17f);
+        noiseGenerator.SetFractalGain(0.62f);
+
+        // noiseGenerator.SetDomainWarpType(FastNoiseLite::DomainWarpType_BasicGrid);
+        // noiseGenerator.SetDomainWarpAmp(2.5f);
+    }
 
     float generateHills(int x, int z) {
         float noiseVal = noiseGenerator.GetNoise((float)x, (float)z);

--- a/src/core/world/Chunk.cpp
+++ b/src/core/world/Chunk.cpp
@@ -142,7 +142,6 @@ void Chunk::generateMesh(std::vector<Vertex>& vertices, std::vector<GLuint>& ind
 
                 bool transparent = block.isTransparent;
 
-                // Handle model blocks (like covered_cross)
                 if (block.model == "covered_cross") {
                     addCoveredCrossMesh(
                         block, x, y, z,
@@ -153,7 +152,6 @@ void Chunk::generateMesh(std::vector<Vertex>& vertices, std::vector<GLuint>& ind
                     continue;
                 }
 
-                // Regular cube faces
                 for (int face = 0; face < 6; ++face) {
                     glm::ivec3 offset = FACE_OFFSETS[face];
                     int nx = x + offset.x;

--- a/src/core/world/World.cpp
+++ b/src/core/world/World.cpp
@@ -426,7 +426,7 @@ bool World::wouldBlockOverlapPlayer(const glm::ivec3& blockPos) const {
 void World::saveChunkToFile(const std::shared_ptr<Chunk>& chunk) {
     const ChunkPosition& pos = chunk->getPosition();
     std::ostringstream oss;
-    oss << saveDirectory << "/chunks/" << pos.x << "_" << pos.y << "_" << pos.z << ".bin.zst";
+    oss << saveDirectory << "/chunks/" << pos.x << "_" << pos.y << "_" << pos.z << ".zst";
     std::string filename = oss.str();
 
     std::vector<char> buffer;
@@ -471,7 +471,7 @@ void World::saveChunkToFile(const std::shared_ptr<Chunk>& chunk) {
 // Loads the chunk from a file
 bool World::loadChunkFromFile(const ChunkPosition& pos, std::shared_ptr<Chunk>& chunkOut) {
     std::ostringstream oss;
-    oss << saveDirectory << "/chunks/" << pos.x << "_" << pos.y << "_" << pos.z << ".bin.zst";
+    oss << saveDirectory << "/chunks/" << pos.x << "_" << pos.y << "_" << pos.z << ".zst";
     std::string filename = oss.str();
 
     if (!std::filesystem::exists(filename)) return false;

--- a/src/utils/GLUtils.cpp
+++ b/src/utils/GLUtils.cpp
@@ -1,4 +1,5 @@
 #include "utils/GLUtils.h"
+#include "core/game/Game.h"
 
 bool loadGlad() {
     return gladLoadGLLoader((GLADloadproc)glfwGetProcAddress);
@@ -23,13 +24,13 @@ void framebufferSizeCallback(GLFWwindow* window, int width, int height) {
 
 bool createWindow(GLFWwindow*& window, const char* title, unsigned int width, unsigned int height, GLFWframebuffersizefun framebufferSizeCallback) {
 
-    window = glfwCreateWindow(width, height, title, NULL, NULL);
+    window = glfwCreateWindow(width, height, title, nullptr, nullptr);
 
     if (!window) {
         std::cerr << "Failed to create GLFW window" << std::endl;
         return false;
     }
-    
+
     glfwMakeContextCurrent(window);
     glfwSetFramebufferSizeCallback(window, framebufferSizeCallback);
 
@@ -40,10 +41,21 @@ bool createWindow(GLFWwindow*& window, const char* title, unsigned int width, un
 
     glViewport(0, 0, width, height);
 
+    std::string iconPath = Game::instance().getBasePath() + "/assets/icon/icon.png";
+
+    if (!std::filesystem::exists(iconPath)) {
+        std::cerr << "Icon file not found at: " << iconPath << "\n";
+    }
+
     GLFWimage images[1];
-    images[0].pixels = stbi_load("../../assets/icon/icon.png", &images[0].width, &images[0].height, 0, 4);
-    glfwSetWindowIcon(window, 1, images);
-    stbi_image_free(images[0].pixels);
+    images[0].pixels = stbi_load(iconPath.c_str(), &images[0].width, &images[0].height, 0, 4);
+
+    if (images[0].pixels) {
+        glfwSetWindowIcon(window, 1, images);
+        stbi_image_free(images[0].pixels);
+    } else {
+        std::cerr << "Warning: Could not load window icon: " << iconPath << std::endl;
+    }
 
     return true;
 }


### PR DESCRIPTION
Chunk data and meshes are now stored as compressed binary files upon being removed from the screen.

Loading new chunks will look for the chunk file before terrain gen and meshing takes place, speeding up chunk generation by 4 or 5x the speed (if the chunks are pre-existing)

Refactored all ../../ hardcoded paths to now be more dynamic.

Implements #55 and #10 